### PR TITLE
credit_cardとsns_credentialsのカラム名の修正。

### DIFF
--- a/db/migrate/20191019083050_create_credit_cards.rb
+++ b/db/migrate/20191019083050_create_credit_cards.rb
@@ -3,7 +3,7 @@ class CreateCreditCards < ActiveRecord::Migration[5.0]
     create_table :credit_cards do |t|
       t.string :customer_id, null: false
       t.string :card_id, null: false
-      t.references :user_id, null: false, foreign_key:true
+      t.references :user, null: false, foreign_key:true
     end
   end
 end

--- a/db/migrate/20191019113653_create_sns_credentials.rb
+++ b/db/migrate/20191019113653_create_sns_credentials.rb
@@ -4,7 +4,7 @@ class CreateSnsCredentials < ActiveRecord::Migration[5.0]
       t.string      :uid, null: false, unique: true
       t.string      :provider, null: false
       t.text        :token
-      t.references  :user_id,null: false, foreign_key: true
+      t.references  :user,null: false, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,51 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191013040612) do
+ActiveRecord::Schema.define(version: 20191019113653) do
+
+  create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "credit_cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string  "customer_id", null: false
+    t.string  "card_id",     null: false
+    t.integer "user_id",     null: false
+    t.index ["user_id"], name: "index_credit_cards_on_user_id", using: :btree
+  end
+
+  create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "sign_ups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "sns_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "uid",                      null: false
+    t.string   "provider",                 null: false
+    t.text     "token",      limit: 65535
+    t.integer  "user_id",                  null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["user_id"], name: "index_sns_credentials_on_user_id", using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -24,4 +68,6 @@ ActiveRecord::Schema.define(version: 20191013040612) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "credit_cards", "users"
+  add_foreign_key "sns_credentials", "users"
 end


### PR DESCRIPTION
# what
 外部キーのカラム名が間違っているので修正。
# why
外部キーのカラム名が間違っているのでエラーが起きるので、起きないように修正のため。