### PR TITLE
Mypage users identification update

### DIFF
--- a/app/assets/stylesheets/users/_identificaiton.scss
+++ b/app/assets/stylesheets/users/_identificaiton.scss
@@ -52,6 +52,12 @@
             display: inline-block;
             font-size: 14px;
           }
+          p {
+            margin: 8px 0 0;
+            line-height: 1.5;
+            font-size: 14px;
+            color: rgb(51, 51, 51);
+          }
           span {
             background: #ccc;
             margin: 0 0 0 8px;

--- a/app/controllers/sign_ups_controller.rb
+++ b/app/controllers/sign_ups_controller.rb
@@ -1,6 +1,7 @@
 class SignUpsController < ApplicationController
 
   def new
+    # メアド・google・facebookでのログイン画面
   end
 
   def register

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
   def new
+    @user = User.new
   end
 
   def show
@@ -10,9 +11,11 @@ class UsersController < ApplicationController
   end
 
   def edit
+    @user = User.find(params[:id])
   end
 
   def identification
+    # @user_address = UserAddress.find_by(user_id: current_user.id)
   end
 
   def logout

--- a/app/models/user_address.rb
+++ b/app/models/user_address.rb
@@ -5,5 +5,6 @@ class UserAddress < ApplicationRecord
   #郵便番号は***-****の8桁にて制限。文字タイプの制限が必要であれば追記お願いします。
   # ハイフン抜き・数字のみ
   validates :Postal_code, length: { is: 7 }, numericality: { only_integer: true }
+  
 
 end

--- a/app/views/sign_ups/register.html.haml
+++ b/app/views/sign_ups/register.html.haml
@@ -266,7 +266,7 @@
           = link_to '利用規約', '#'
           に同意したものとみなします
         .new-registration-page__main__box__next-button
-          = link_to authentication_sign_up_path do
+          = link_to authentication_sign_ups_path do
             .new-registration-page__main__box__text
               次へ進む
         .new-registration-page__main__box__about-registration

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -16,13 +16,13 @@
               = fa_icon 'angle-right', class: 'text-right__link__icon'
         .wrapper__contents__container__inner__form
           %label お名前
-          %input{type: 'text', value: '', placeholder: '例)山田 花子'}
+          %p 次郎丸
         .wrapper__contents__container__inner__form
           %label お名前カナ
-          %input{type: 'text', value: '', placeholder: '例)ヤマダ ハナコ'}
+          %p ジロウマル
         .wrapper__contents__container__inner__form
           %label 生年月日
-          %input{type: 'text', value: '', placeholder: '例)1993年12月25日'}
+          %p 1900/01/01
         .wrapper__contents__container__inner__form
           %label 郵便番号
           %span 任意


### PR DESCRIPTION
# What
メルカリ本人情報の登録画面の改良
お名前・お名前カナ・生年月日のinputタグを削除
# Why
ここは元々記述がなされているので
<img width="1440" alt="スクリーンショット 2019-10-27 8 20 05" src="https://user-images.githubusercontent.com/51882063/67627212-9ded5080-f892-11e9-971f-3356f4370fbd.png">
