### PR TITLE
SellItem:optional:true About buyer_id

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,6 +46,7 @@ class ItemsController < ApplicationController
       :price,
       :shipping_address,
       :status,
+      :buyer_id,
       images_attributes: [:image]
       # images_attributes: {images: []}
     ).merge(seller_id: current_user.id)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   # belongs_to :brand
   # belongs_to :category
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
-  # belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id' fkをつけているためnillが許されない。中間テーブル(userとitem間)作成
+  belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id', optional: true
   # belongs_to :shipping_address
   has_many :comments, dependent: :destroy
   has_many :images, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ has_many :sns_credentials, dependent: :destroy
 has_many :likes, dependent: :destroy
 has_many :comments, dependent: :destroy
 has_many :seller_items, class_name: 'Item', foreign_key: 'seller_id', dependent: :destroy
-# has_many :buyer_items, class_name: 'Item', foreign_key: 'buyer_id', dependent: :destroy
+has_many :buyer_items, class_name: 'Item', foreign_key: 'buyer_id', dependent: :destroy
 has_one :user_address, dependent: :destroy
 has_one :credit_cards, dependent: :destroy
 has_one :shipping_address, dependent: :destroy

--- a/db/migrate/20191020200333_create_items.rb
+++ b/db/migrate/20191020200333_create_items.rb
@@ -13,7 +13,7 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.string     :category             #null: false
       t.integer    :price                #null: false 
       t.references :seller,                            foreign_key: {to_table: :users}
-      # t.references :buyer,                             foreign_key: {to_table: :users}
+      t.references :buyer,                             foreign_key: {to_table: :users}
       t.string     :status               #null: false, default: ""
       t.timestamps
     end


### PR DESCRIPTION
# What
モデル、コントローラ、マイグレーションファイルそれぞれにbuyer_idに関する記述を追加
モデルのbuyer_idにoptional:trueを追加
# Why
商品出品時のbuyer_idに対するnillを許可するため