### PR TITLE
トップページビュー修正

### DIFF
--- a/app/controllers/mains_controller.rb
+++ b/app/controllers/mains_controller.rb
@@ -3,7 +3,7 @@ class MainsController < ApplicationController
   def index
     ranking1 = @publishing_item.group(:parent_id).order('count_parent_id DESC').limit(4).count(:parent_id).keys
 
-    @categories = Category.where(id: ranking1)
+    @categories = Category.where(id: ranking1).order("FIELD(id, #{ranking1.join(',')})")
     
     @category1 = Category.find_by(id: ranking1[0])
     @items1 = @publishing_item.where(parent_id: ranking1[0]).order('id DESC').limit(6)

--- a/app/controllers/mains_controller.rb
+++ b/app/controllers/mains_controller.rb
@@ -5,16 +5,12 @@ class MainsController < ApplicationController
 
     @categories = Category.where(id: ranking1).order("FIELD(id, #{ranking1.join(',')})")
     
-    @category1 = Category.find_by(id: ranking1[0])
     @items1 = @publishing_item.where(parent_id: ranking1[0]).order('id DESC').limit(6)
     
-    @category2 = Category.find_by(id: ranking1[1])
     @items2 = @publishing_item.where(parent_id: ranking1[1]).order('id DESC').limit(6)
     
-    @category3 = Category.find_by(id: ranking1[2])
     @items3 = @publishing_item.where(parent_id: ranking1[2]).order('id DESC').limit(6)
 
-    @category4 = Category.find_by(id: ranking1[3])
     @items4 = @publishing_item.where(parent_id: ranking1[3]).order('id DESC').limit(6)
   end
 

--- a/app/controllers/mains_controller.rb
+++ b/app/controllers/mains_controller.rb
@@ -1,7 +1,9 @@
 class MainsController < ApplicationController
   before_action :get_publishing_item, only: [:index]
   def index
-    ranking1 = @publishing_item.group(:parent_id).order('count_parent_id DESC').limit(6).count(:parent_id).keys
+    ranking1 = @publishing_item.group(:parent_id).order('count_parent_id DESC').limit(4).count(:parent_id).keys
+
+    @categories = Category.where(id: ranking1)
     
     @category1 = Category.find_by(id: ranking1[0])
     @items1 = @publishing_item.where(parent_id: ranking1[0]).order('id DESC').limit(6)

--- a/app/views/items/_body.html.haml
+++ b/app/views/items/_body.html.haml
@@ -38,20 +38,20 @@
             = link_to category.name, '#'
 
   .top-page__new-items
-    -unless @category1.nil?
+    -unless @categories[0].nil?
       .top-page__category
         .top-page__category__new-items
-          = "#{@category1.name}新着アイテム"
+          = "#{@categories[0].name}新着アイテム"
           -if @items1.length >= 6
             .top-page__category__new-items__more
               = link_to 'もっと見る ＞', '#' 
         .top-page__category__largebox
           - @items1.first(5).each do |item|
             = render partial: 'items/categorybox', locals: { item: item }
-    -unless @category2.nil?   
+    -unless @categories[1].nil?   
       .top-page__category
         .top-page__category__new-items
-          = "#{@category2.name}新着アイテム"
+          = "#{@categories[1].name}新着アイテム"
           -if @items2.length >= 6
             .top-page__category__new-items__more
               = link_to 'もっと見る ＞', '#' 
@@ -59,20 +59,20 @@
           - @items2.first(5).each do |item|
             = render partial: 'items/categorybox', locals: { item: item }
 
-    -unless @category3.nil?
+    -unless @categories[2].nil?
       .top-page__category
         .top-page__category__new-items
-          = "#{@category3.name}新着アイテム"
+          = "#{@categories[2].name}新着アイテム"
           -if @items3.length >= 6
             .top-page__category__new-items__more
               = link_to 'もっと見る ＞', '#'
         .top-page__category__largebox
           - @items3.first(5).each do |item|
             = render partial: 'items/categorybox', locals: { item: item }
-    -unless @category4.nil?
+    -unless @categories[3].nil?
       .top-page__category
         .top-page__category__new-items
-          = "#{@category4.name}新着アイテム"
+          = "#{@categories[3].name}新着アイテム"
           -if @items4.length >= 6
             .top-page__category__new-items__more
               = link_to 'もっと見る ＞', '#'

--- a/app/views/items/_body.html.haml
+++ b/app/views/items/_body.html.haml
@@ -28,19 +28,15 @@
             ●
           .top-page__trendy-box__article__dot-right
             ○
-  .top-page__popular-categories
-    .top-page__heading-line
-      人気のカテゴリー
-    %ul.top-page__menu
-      %li.top-page__menu__item
-        = link_to 'レディース', '#'
-      %li.top-page__menu__item
-        = link_to 'メンズ', '#'
-      %li.top-page__menu__item
-        = link_to '家電・スマホ・カメラ', '#'
-      %li.top-page__menu__item
-        = link_to 'おもちゃ・ホビー・グッズ', '#'
-    
+  -unless @publishing_item.blank?          
+    .top-page__popular-categories
+      .top-page__heading-line
+        人気のカテゴリー 
+      %ul.top-page__menu
+        - @categories.each do |category| 
+          %li.top-page__menu__item
+            = link_to category.name, '#'
+
   .top-page__new-items
     -unless @category1.nil?
       .top-page__category
@@ -83,21 +79,23 @@
         .top-page__category__largebox
           - @items4.first(5).each do |item|
             = render partial: 'items/categorybox', locals: { item: item }
-  .top-page__popular-categories
-    .top-page__heading-line
-      人気のブランド
-    %ul.top-page__menu
-      %li.top-page__menu__item
-        = link_to 'シャネル', '#'
-      %li.top-page__menu__item
-        = link_to 'ルイヴィトン', '#'
-      %li.top-page__menu__item
-        = link_to 'シュプリーム', '#'
-      %li.top-page__menu__item
-        = link_to 'ナイキ', '#'
 
 = render 'shared/exhibition-button'
+
 -# 以下、出品画面でブランド入力可能になった後に実装します
+  -# .top-page__popular-categories
+  -#   .top-page__heading-line
+  -#     人気のブランド
+  -#   %ul.top-page__menu
+  -#     %li.top-page__menu__item
+  -#       = link_to 'シャネル', '#'
+  -#     %li.top-page__menu__item
+  -#       = link_to 'ルイヴィトン', '#'
+  -#     %li.top-page__menu__item
+  -#       = link_to 'シュプリーム', '#'
+  -#     %li.top-page__menu__item
+  -#       = link_to 'ナイキ', '#'
+
   -# .top-page__new-items
   -#   .top-page__category
   -#     .top-page__category__new-items


### PR DESCRIPTION
What
「人気のカテゴリ」以下のカテゴリ表示が、仮置きではなく出品商品によって表示が変わるようにした(gyazo参照)
Why
売れてる商品をわかりやすくするため

https://gyazo.com/0a4cf330a64593d7842c5a2286e74701