### PR TITLE
モーダルウィンドウ編集

### DIFF
--- a/app/assets/stylesheets/shared/_item-new.scss
+++ b/app/assets/stylesheets/shared/_item-new.scss
@@ -106,7 +106,15 @@
               line-height: 44px;
               text-align: center;
               border-top: 1px solid $separator;
+              cursor: pointer;
+              color: $item-new-link;
             }
+              &--edit:hover {
+                background: #f8f8f8;
+                text-decoration: underline;
+                color: $item-new-link-hover;
+                text-decoration-color: $item-new-link-hover;
+              }
             &--delete {
               float: right;
               width: 49%;
@@ -116,6 +124,13 @@
               border-left: 1px solid $separator;
               border-top: 1px solid $separator;
               cursor: pointer;
+              color: $item-new-link;
+            }
+            &--delete:hover {
+              background: #f8f8f8;
+              text-decoration: underline;
+              color: $item-new-link-hover;
+              text-decoration-color: $item-new-link-hover;
             }
           }
         }

--- a/app/assets/stylesheets/variable/_colors.scss
+++ b/app/assets/stylesheets/variable/_colors.scss
@@ -5,11 +5,13 @@ $separator: #eee;
 $base-font: #333;
 //ベース背景カラー(aya)
 $base-background: #fff;
+
 //必須表示
 ///必須表示ベースカラー(aya)
 $require-red: #ea352d;
 ///必須表示文字カラー(aya)
 $require-white: #fff;
+
 //プルダウン
 ///プルダウンアイコンカラー(aya)
 $pulldown-icon: #888;
@@ -24,6 +26,11 @@ $item-sell-btn:#ea352d;
 //アイテム出品ボタン文字カラー（出品/もどる）(aya)
 $item-sell-btn-font: #fff;
 
+// リンク(aya)
+$item-new-link: #0099e8;
+
+// リンクhover(aya)
+$item-new-link-hover: #66B9F0;
 
 
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,4 +2,7 @@ class Image < ApplicationRecord
   # アイテム用のイメージモデル
   mount_uploader :image, ImageUploader
   belongs_to :item, optional: true
+
+
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
   belongs_to :category, optional: true
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
   belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id', optional: true
-  # belongs_to :shipping_address
+  belongs_to :shipping_address
   #has_many :comments, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,7 @@ class Item < ApplicationRecord
   belongs_to :category, optional: true
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
   belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id', optional: true
+  # belongs_to :shipping_address
   #has_many :comments, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,6 @@ class Item < ApplicationRecord
   belongs_to :category, optional: true
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
   belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id', optional: true
-  # belongs_to :shipping_address
   #has_many :comments, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/views/items/_new-body.html.haml
+++ b/app/views/items/_new-body.html.haml
@@ -141,4 +141,4 @@
         あなたが出品した商品は「出品した商品一覧」からいつでも見ることができます。
       =link_to "続けて出品する", new_item_path, class: 'item-create__box__btn', data: {"turbolinks" => false}
       %p.item-create__box__share
-        =link_to "商品ページへ行ってシェアする",  root_path
+        =link_to "トップページへ戻る", root_path


### PR DESCRIPTION
# What
モーダルウィンドウのリンク編集
-商品出品ページへのリンクをリロードした上で推移できるよう編集した
(リロードしないと前回出品時の画像数をカウントしたママになってしまうため）
-トップページと再出品ページの２つのリンクを作った
プレビュー画像の編集
-プレビュー画像の削除と編集ボタンにカーソルを合わせた際に色が変わるようにした
 # Why
ユーザーが直感的に理解できるようにするため