### PR TITLE
出品ページ金額表示の修正

### DIFF
--- a/app/assets/javascripts/sellingprice.js
+++ b/app/assets/javascripts/sellingprice.js
@@ -9,8 +9,8 @@ $(document).on('turbolinks:load', function () {
       ItemProfit.text('-');
     } else {
       let SellingPrice = ItemPrice.val();
-      let SellingFee = Math.floor(SellingPrice * 0.1);
-      let SellingProfit = SellingPrice - SellingFee
+      let SellingFee = String(Math.floor(SellingPrice * 0.1)).replace( /(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      let SellingProfit = String(Math.floor(SellingPrice * 0.9)).replace( /(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
       ItemFee.text('¥' + SellingFee);
       ItemProfit.text('¥' + SellingProfit);
     }

--- a/app/views/items/_new-body.html.haml
+++ b/app/views/items/_new-body.html.haml
@@ -119,7 +119,7 @@
               .yen
                 ¥
                 .yen__box
-                  = f.text_field :price, class: 'price-input',placeholder: "例）300",  maxlength: 7
+                  = f.text_field :price, class: 'price-input',placeholder: "例）300",  maxlength: 9
             %li.sell-form.clearfix
               .sell-form__sentence
                 販売手数料 (10%)


### PR DESCRIPTION
#what 出品ページ金額表示の修正

##why 金額を表示する時にカンマを表示させて方が、わかりやすいから。 