### PR TITLE
公開停止中であれば「購入する」ボタン出現させないようにした

### DIFF
--- a/app/views/items/_show-body.html.haml
+++ b/app/views/items/_show-body.html.haml
@@ -83,7 +83,7 @@
       %span.product-details__main__price-box__tax (税込)
       %span.product-details__main__price-box__shipping-fee 
         = @item.shipping_fee.name.delete'(出品者負担)'   
-    - if current_user&.id != @item.seller_id && @item.buyer_id.nil?   
+    - if current_user&.id != @item.seller_id && @item.buyer_id.nil? && @item.status.nil?
       .product-details__main__buy-btn
         = link_to '購入画面に進む', new_item_purchase_path(@item), class: 'btn product-details__main__buy-btn' 
     - elsif current_user&.id != @item.seller_id && @item.buyer_id  


### PR DESCRIPTION
What
詳細画面/公開停止中であれば「購入する」ボタン出現させないようにした
Why
公開停止機能を活かすため